### PR TITLE
skip google analytics if not installed

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,3 +12,6 @@ level = 2
 [preprocessor.toc]
 command = "mdbook-toc"
 renderer = ["html"]
+
+[output.html-google-analytics]
+optional = true


### PR DESCRIPTION
Add an optional flag to skip google analytics if the backend plugin is not installed.